### PR TITLE
영어 솎솎 배율 밸런스 조정

### DIFF
--- a/Server/lib/Game/kkutu.js
+++ b/Server/lib/Game/kkutu.js
@@ -1438,7 +1438,7 @@ function getRewards(mode, score, bonus, rank, all, ss){
 			rw.score += score * 10.0;
 			break;
 		case 'ESS':
-			rw.score += score * 10.0;
+			rw.score += score * 1.0;
 			break;
 		default:
 			break;


### PR DESCRIPTION
영어 솎솎같은 경우 자동으로 단어를 솎솎 골라줘야 하는데 이 기능은 현재 저런끄투에는 제작되지 않았습니다.
턴마다 계속 같은 것이 나옵니다.
(한솎은 알아서 알고리즘이 골라줌.)
++ 영어 솎솎 단어를 자동으로 골라주는 기능을 만들기 전까지는 이를 악용할수 있을수 있기에 PR을 생성했습니다.